### PR TITLE
Update typescript to 3.8.2 to fix parsing errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-native-windows": "^0.61.0-beta.58",
     "rnpm-plugin-windows": "^0.5.1-0",
     "semantic-release": "15.13.24",
-    "typescript": "3.6.2"
+    "typescript": "3.8.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
With `test.js` containing an example of syntax used in this project and/or deps:
```
import type { DiffOptions } from './types';
```

Current behavior (<=3.7.5), error occurs due to parsing errors:
```
$ npx typescript@3.7.5 test.ts

npx: installed 1 in 4.481s
test.ts:1:13 - error TS1005: '=' expected.

1 import type { DiffOptions } from './types';
              ~

test.ts:1:34 - error TS1005: ';' expected.

1 import type { DiffOptions } from './types';
                                   ~~~~~~~~~
Found 2 errors.
```

Desired behavior (>=3.8.2), no parsing errors (still shows error because the random module doesn't exist, but this test only cares about the parsing errors so it's expected):
```
$ npx typescript@3.8.2 test.ts

npx: installed 1 in 4.899s
test.ts:1:34 - error TS2307: Cannot find module './types'.

1 import type { DiffOptions } from './types';
                                   ~~~~~~~~~
Found 1 error.
```

Parent repo has 3.8.3, but 3.8.2 is sufficient to resolve the immediate parsing issue that was blocking me. Consider merging changes from parent repo frequently.